### PR TITLE
specular bits removed

### DIFF
--- a/spago.dhall
+++ b/spago.dhall
@@ -35,7 +35,6 @@ to generate this file without the comments in this block.
 , packages = ./packages.dhall
 , sources =
   [ "src/**/*.purs"
-  , "src-specular-bits/**/*.purs"
   , "test/**/*.purs"
   , "demo/1/*.purs"
   ]

--- a/src/Web/Internal/DOM.purs
+++ b/src/Web/Internal/DOM.purs
@@ -44,8 +44,8 @@ import Effect.Unsafe (unsafePerformEffect)
 import Foreign.Object (Object)
 import Foreign.Object as Object
 import Propagator (class MonadGUI)
-import Specular.Internal.RIO (RIO, runRIO)
-import Specular.Internal.RIO as RIO
+import Web.Internal.RIO (RIO, runRIO)
+import Web.Internal.RIO as RIO
 import Unsafe.Coerce (unsafeCoerce)
 
 newtype DOM a = DOM (RIO DOMEnv a)

--- a/src/Web/Internal/RIO.js
+++ b/src/Web/Internal/RIO.js
@@ -47,13 +47,6 @@ export function runRIO(env) {
   };
 }
 
-// rio :: forall r a. (r -> IOSync a) -> RIO r a
-export function rio(f) {
-  return function RIO_rio_eff(env) {
-    return f(env)();
-  };
-}
-
 // local :: forall r e a. (e -> r) -> RIO r a -> RIO e a
 export function local(f) {
   return function (io) {

--- a/src/Web/Internal/RIO.purs
+++ b/src/Web/Internal/RIO.purs
@@ -1,6 +1,6 @@
-module Specular.Internal.RIO
+-- This is based on https://pursuit.purescript.org/packages/purescript-specular/0.13.1/docs/Specular.Internal.RIO
+module Web.Internal.RIO
   ( RIO(..)
-  , rio
   , runRIO
   , local
   ) where
@@ -15,24 +15,24 @@ import Unsafe.Coerce (unsafeCoerce)
 
 newtype RIO r a = RIO (EffectFn1 r a)
 
-instance functorRIO :: Functor (RIO r) where
+instance Functor (RIO r) where
   map = mapImpl
 
-instance applyRIO :: Apply (RIO r) where
+instance Apply (RIO r) where
   apply = applyImpl
 
-instance applicativeRIO :: Applicative (RIO r) where
+instance Applicative (RIO r) where
   pure = pureImpl
 
-instance bindRIO :: Bind (RIO r) where
+instance Bind (RIO r) where
   bind = bindImpl
 
-instance monadRIO :: Monad (RIO r)
+instance Monad (RIO r)
 
-instance monadAskRIO :: MonadAsk r (RIO r) where
+instance MonadAsk r (RIO r) where
   ask = askImpl
 
-instance monadEffectRIO :: MonadEffect (RIO r) where
+instance MonadEffect (RIO r) where
   liftEffect = unsafeCoerce
 
 foreign import pureImpl :: forall r a. a -> RIO r a
@@ -40,7 +40,5 @@ foreign import mapImpl :: forall r a b. (a -> b) -> RIO r a -> RIO r b
 foreign import applyImpl :: forall r a b. RIO r (a -> b) -> RIO r a -> RIO r b
 foreign import bindImpl :: forall r a b. RIO r a -> (a -> RIO r b) -> RIO r b
 foreign import askImpl :: forall r. RIO r r
-
 foreign import runRIO :: forall r a. r -> RIO r a -> Effect a
-foreign import rio :: forall r a. (r -> Effect a) -> RIO r a
 foreign import local :: forall r e a. (e -> r) -> RIO r a -> RIO e a


### PR DESCRIPTION
The last module originally taken from Specular is RIO which is small enough to move it to main source codebase.