### PR TITLE
Widget with ReaderT

### DIFF
--- a/demo/1/Model.purs
+++ b/demo/1/Model.purs
@@ -69,7 +69,7 @@ formal = iso "formal" toFormal toInformal
     toInformal :: NameFormal -> NameInformal
     toInformal { forename, surname } = { firstName: forename, lastName: surname }
 
-submitOrder :: forall m. MonadEffect m => Widget m Order Order
+submitOrder :: forall env m. MonadEffect m => Widget env m Order Order
 submitOrder = submitOrderEffect # lens (\order -> SubmitOrderRequest { orderSerialized: serializeOrder order}) (\order (SubmitOrderResponse { orderUniqueId }) -> order { uniqueId = orderUniqueId })
   where
     serializeOrder :: Order -> String
@@ -78,7 +78,7 @@ submitOrder = submitOrderEffect # lens (\order -> SubmitOrderRequest { orderSeri
         (Takeaway { time }) -> "takeaway|" <> time
         (Delivery { address }) -> "delivery|\"" <> address <> "\""
       ]
-    submitOrderEffect :: Widget m SubmitOrderRequest SubmitOrderResponse
+    submitOrderEffect :: Widget env m SubmitOrderRequest SubmitOrderResponse
     submitOrderEffect = effect \request -> do
       liftEffect $ log $ show request
       pure $ SubmitOrderResponse { orderUniqueId: "HAJ78" }

--- a/src/Widget.purs
+++ b/src/Widget.purs
@@ -58,7 +58,7 @@ newtype Widget m i o = Widget (m
 --     monitoring
 --     analytics
 --     authorization
---     curren time
+--     current time
 --     localization
 --   UI-specific:
 --     scheduleNotification :: NotificationOptions -> Effect Unit
@@ -70,6 +70,7 @@ newtype Widget m i o = Widget (m
 --     onPushNotification :: (PushMessage -> Effect Unit) -> Effect Unit
 --     printing
 --     media type
+--     sounds
 
 type Propagation m a = Change a -> m Unit
 

--- a/src/Widget.purs
+++ b/src/Widget.purs
@@ -58,6 +58,8 @@ newtype Widget m i o = Widget (m
 --     monitoring
 --     analytics
 --     authorization
+--     curren time
+--     localization
 --   UI-specific:
 --     scheduleNotification :: NotificationOptions -> Effect Unit
 --     updateNotification :: NotificationOptions -> Effect Unit

--- a/src/Widget.purs
+++ b/src/Widget.purs
@@ -49,6 +49,26 @@ newtype Widget m i o = Widget (m
   , listen :: Propagation m o -> m Unit
   })
 
+-- things that can `ReaderT r m` can enable:
+--   UI-independent:
+--     platform
+--     app metadata e.g verion
+--     feature flags
+--     logging
+--     monitoring
+--     analytics
+--     authorization
+--   UI-specific:
+--     scheduleNotification :: NotificationOptions -> Effect Unit
+--     updateNotification :: NotificationOptions -> Effect Unit
+--     clearNotification :: NotificationId -> Effect Unit
+--     onClickNotification :: (NotificationOptions -> Effect Unit) -> Effect Unit
+--     device permissions - checking/fixing
+--     sounds (or rather it should be widget?)
+--     onPushNotification :: (PushMessage -> Effect Unit) -> Effect Unit
+--     printing
+--     media type
+
 type Propagation m a = Change a -> m Unit
 
 derive instance Newtype (Widget m i o) _

--- a/src/Widget.purs
+++ b/src/Widget.purs
@@ -60,6 +60,7 @@ newtype Widget m i o = Widget (m
 --     authorization
 --     current time
 --     localization
+--     user context 
 --   UI-specific:
 --     scheduleNotification :: NotificationOptions -> Effect Unit
 --     updateNotification :: NotificationOptions -> Effect Unit


### PR DESCRIPTION
As Widget works for any monad `m`, we can take advantage of wrapping `m` with any monad transfomer.

ReaderT, for instance, can provide application context to Widgets. 